### PR TITLE
feat: add commit-check reusable workflow and org-level config

### DIFF
--- a/cchk.toml
+++ b/cchk.toml
@@ -1,0 +1,23 @@
+[commit]
+# https://www.conventionalcommits.org
+conventional_commits = true
+subject_capitalized = false
+subject_imperative = true
+subject_max_length = 100
+subject_min_length = 5
+allow_commit_types = ["feat", "fix", "docs", "style", "refactor", "test", "chore", "ci"]
+allow_merge_commits = true
+allow_revert_commits = true
+allow_empty_commits = false
+allow_fixup_commits = true
+allow_wip_commits = false
+require_body = false
+require_signed_off_by = false
+ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "coderabbitai[bot]"]
+
+[branch]
+# https://conventional-branch.github.io/
+conventional_branch = true
+allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "ai", "claude", "codex", "copilot", "cursor"]
+require_rebase_target = "main"
+ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "shenxianpeng"]


### PR DESCRIPTION
- Add cchk.toml as the organization-level base config for inherit_from
- Add commit-check reusable workflow (.github/workflows/commit-check.yml) for other repositories to consume
- Add commit-check-self.yml for the .github repo to eat its own dog food

The cchk.toml serves as the shared base config that other repos can inherit via:
  inherit_from = "github:commit-check/.github:cchk.toml"

Other repos can reuse the workflow by calling:
  commit-check/.github/.github/workflows/commit-check.yml@main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated commit message and branch name validation on all pushes to main and pull requests
  * Validation enforces Conventional Commits standards including commit message format, branch naming conventions, and PR title requirements
  * Improves repository consistency and code quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->