### PR TITLE
feat: add org-level commit-check.toml and dogfooding workflow

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,0 +1,25 @@
+name: Commit Check
+
+on:
+  pull_request:
+    branches: 'main'
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+
+jobs:
+  commit-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v7.0.0
+        with:
+          fetch-depth: 0  # Required for merge-base checks
+      - uses: commit-check/commit-check-action@v2.10.0
+        with:
+          message: true
+          branch: true
+          job-summary: true
+          pr-comments: true
+          pr-title: true

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v7.0.0
         with:
           fetch-depth: 0  # Required for merge-base checks
+      - name: Ensure base branch ref exists for merge-base check
+        run: git fetch origin main:main
       - uses: commit-check/commit-check-action@v2.10.0
         with:
           message: true

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v7.0.0
         with:
           fetch-depth: 0  # Required for merge-base checks
-      - name: Ensure base branch ref exists for merge-base check
-        run: git fetch origin main:main
       - uses: commit-check/commit-check-action@v2.10.0
         with:
           message: true

--- a/commit-check.toml
+++ b/commit-check.toml
@@ -1,0 +1,35 @@
+# ============================================================================
+# commit-check — org-level base configuration
+#
+# Repos within the commit-check org can inherit this config by placing the
+# following directive at the top of their own commit-check.toml:
+#
+#   inherit_from = "github:commit-check/.github:commit-check.toml"
+#
+# Local settings override the inherited values (shallow merge per section).
+# See https://github.com/commit-check/commit-check for full documentation.
+# ============================================================================
+
+[commit]
+# https://www.conventionalcommits.org
+conventional_commits = true
+subject_capitalized = false
+subject_imperative = true
+subject_max_length = 100
+subject_min_length = 5
+allow_commit_types = ["feat", "fix", "docs", "style", "refactor", "test", "chore", "ci"]
+allow_merge_commits = true
+allow_revert_commits = true
+allow_empty_commits = false
+allow_fixup_commits = true
+allow_wip_commits = false
+require_body = false
+require_signed_off_by = false
+ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "coderabbitai[bot]"]
+
+[branch]
+# https://conventional-branch.github.io/
+conventional_branch = true
+allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "ai", "claude", "codex", "copilot", "cursor"]
+require_rebase_target = "main"
+ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "shenxianpeng"]

--- a/commit-check.toml
+++ b/commit-check.toml
@@ -31,5 +31,4 @@ ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "code
 # https://conventional-branch.github.io/
 conventional_branch = true
 allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "ai", "claude", "codex", "copilot", "cursor"]
-require_rebase_target = "main"
 ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "shenxianpeng"]


### PR DESCRIPTION
## Summary

Create an org-level `commit-check.toml` as a single source of truth for commit and branch conventions across the `commit-check` org.

### Changes

1. **`commit-check.toml`** (root) — Org-level base configuration that all repos can inherit via:
   ```toml
   inherit_from = "github:commit-check/.github:commit-check.toml"
   ```
   - Enforces Conventional Commits and Conventional Branch naming
   - Includes common bot ignore lists (`dependabot`, `copilot`, `pre-commit-ci`, `coderabbitai`)
   - Allows AI agent branch prefixes (`ai/`, `claude/`, `codex/`, `copilot/`, `cursor/`)

2. **`.github/workflows/commit-check.yml`** — Dogfooding workflow that runs commit-check on every PR to `main` of this repo, validating commit messages, branch names, and PR titles.

### Usage in other repos

Add this to any repo's `commit-check.toml`:

```toml
inherit_from = "github:commit-check/.github:commit-check.toml"

# Local overrides (optional)
[commit]
subject_max_length = 72  # override for this repo
```

> **Note:** The `inherit_from` feature is available since commit-check v2.5.0+.

Closes: <!-- (link any related issues if applicable) -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Commit Check” automation that validates pull request commit messages, branch names, and pull request titles, with support for manual runs.
* **Chores**
  * Introduced repository-wide commit and branch formatting rules to keep history consistent.
  * Added allowlisted automation accounts to be excluded from these checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->