### PR TITLE
chore: update release-drafter config (remove CI title autolabel, map pre-commit-ci branch)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -88,7 +88,6 @@ autolabeler:
     title:
       - /^chore(\(.*\))?:.*/
       - /^refactor(\(.*\))?:.*/
-      - /^ci(\(.*\))?:.*/
       - /^style(\(.*\))?:.*/
       - /^build(\(.*\))?:.*/
       - /^revert(\(.*\))?:.*/
@@ -112,6 +111,9 @@ autolabeler:
   - label: tests
     branch:
       - /^test\/.+/
+  - label: dependencies
+    branch:
+      - /^pre-commit-ci-update-config/
 
   # ── File-based ────────────────────────────────────────────
   - label: documentation


### PR DESCRIPTION
### Changes

1. **Remove CI from title autolabeler** — Delete the `ci` prefix title matching rule, so PRs with `ci:` prefix titles won't be auto-labeled as `chore`
2. **Add branch mapping** — Map `pre-commit-ci-update-config` branch to `dependencies` label, so it falls under 📦 Dependencies category

### Rationale

- pre-commit-ci bot may create PRs with `ci:` prefix in titles, which shouldn't be categorized as Maintenance
- `pre-commit-ci-update-config` is essentially a dependency update branch, so it should be categorized under Dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release labeling rules to better classify certain maintenance-related changes.
  * Improved label assignment for dependency update branches so those updates are identified more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->