### PR TITLE
fix: add issues:write permission to PR labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       # write permission is required for autolabeler
       pull-requests: write
+      # labels on pull requests are handled through the Issues labels API
+      issues: write
       contents: read
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

The `release-drafter/release-drafter/autolabeler` action fails with a 403 error when trying to add labels to pull requests:

```
Error: Resource not accessible by integration
```

GitHub's PR label functionality uses the **Issues API** under the hood (`POST /repos/{owner}/{repo}/issues/{issue_number}/labels`), which requires the `issues: write` permission. The current workflow only has `pull-requests: write`, which is insufficient.

## Fix

Add `issues: write` to the `permissions` block in `pr-labeler.yml`.

## History

- `bae071f` — First added `issues: write` (fix)
- `92d9987` — Reverted, removing `issues: write`
- The recent config change in `release-drafter.yml` triggered the autolabeler on new scenarios (e.g. pre-commit bot PRs), exposing this pre-existing permission issue.