### PR TITLE
feat: add SECURITY.md with vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,16 @@
 # Security Policy
 
-If you find a security vulnerability in any Commit Check project, please report it privately.
-
 ## Reporting a Vulnerability
 
-**Do not open a public GitHub issue.** Instead, send an email to:
+If you discover a security vulnerability, please **do not** open a public
+issue. Instead, report it privately via
+[GitHub's private vulnerability reporting](https://github.com/commit-check/REPO/security/advisories/new)
+on the affected repository (replace `REPO` with the actual repository name:
+`commit-check`, `commit-check-action`, `commit-check-mcp`).
 
-**[xianpeng.shen@gmail.com](mailto:xianpeng.shen@gmail.com)**
-
-Please include:
-
-- Which project and version is affected
-- A description of the issue and its impact
-- Steps to reproduce (or a proof of concept)
-
-You will receive an acknowledgment within 48 hours, followed by a plan for resolution.
+We'll respond as quickly as possible and keep you updated throughout the
+process.
 
 ## Supported Versions
 
-Only the latest release of each project receives security patches. Please keep your dependencies up to date.
+Only the latest release of each project receives security patches.


### PR DESCRIPTION
Simplified the org-level SECURITY.md following the style of [cpp-linter/.github/SECURITY.md](https://github.com/cpp-linter/.github/blob/main/SECURITY.md).

Changes:
- **Reporting a Vulnerability**: Use GitHub Private Vulnerability Reporting link, with instructions to replace `REPO` with the actual repo name
- **Supported Versions**: Only latest release receives security patches

From GAP_ANALYSIS_REPORT.md P0 Gap 1 — Missing security policy and vulnerability disclosure process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability reporting instructions to use GitHub’s private reporting feature.
  * Clarified that only the latest release receives security patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->