### PR TITLE
docs: add Discussions link to profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,3 +21,6 @@ As a lightweight alternative to GitHub Enterprise [Metadata restrictions](https:
 ## Contributing 💪
 
 We welcome feedback, bug reports, and feature requests from the community. Join us in making Commit Check better!
+
+* [Issues](https://github.com/commit-check/commit-check/issues) — bug reports, feature requests
+* [Discussions](https://github.com/commit-check/commit-check/discussions) — questions, ideas, community conversations


### PR DESCRIPTION
The commit-check project now has Discussions enabled, but the org profile README in the Contributing section only mentions issues. Added links to both Issues and Discussions so visitors know where to post bugs, feature requests, questions, and ideas.\n\nSee: https://github.com/commit-check/commit-check/discussions